### PR TITLE
Fix playback statistics

### DIFF
--- a/src/ReplicatedStorage/Utils/DateTimeOffset.lua
+++ b/src/ReplicatedStorage/Utils/DateTimeOffset.lua
@@ -1,0 +1,29 @@
+local DateTimeOffset = {}
+
+function DateTimeOffset.GetCurrentUtcOffset()
+	local utcOffsetString = ""
+	
+	-- Get the current UTC time
+	local utcTime = os.time(os.date("!*t"))
+
+	-- Get the local time
+	local localTime = os.time(os.date("*t"))
+
+	-- Calculate the timezone offset in seconds
+	local timezoneOffset = os.difftime(localTime, utcTime)
+
+	-- Convert the offset to hours
+	local timezoneOffsetInHours = timezoneOffset / 3600
+	
+	if timezoneOffsetInHours > 0 then
+		utcOffsetString = string.format("UTC+%0.2i:00", timezoneOffsetInHours)
+	elseif timezoneOffsetInHours < 0 then
+		utcOffsetString = string.format("UTC%0.2i:00", timezoneOffsetInHours)
+	else
+		utcOffsetString = string.format("UTC+00:00", timezoneOffsetInHours)
+	end
+	
+	return utcOffsetString
+end
+
+return DateTimeOffset

--- a/src/ServerScriptService/Modules/StyngrService.lua
+++ b/src/ServerScriptService/Modules/StyngrService.lua
@@ -13,6 +13,7 @@ local Promise = require(ReplicatedStorage.Styngr.Packages.promise)
 local CloudService = require(ServerScriptService.Styngr.Modules.CloudService)
 local Types = require(ServerScriptService.Styngr.Types)
 local ISODurations = require(ReplicatedStorage.Styngr.Utils.ISODurations)
+local DateTimeOffset = require(ReplicatedStorage.Styngr.Utils.DateTimeOffset)
 local BoomboxModel = require(ServerScriptService.Styngr.Modules.BoomboxModel)
 
 local StyngrService = {}
@@ -350,6 +351,7 @@ function StyngrService:RequestNextTrack(player: Player)
 
 	local statistics = self:_endTrack(player.UserId)
 	local duration = ISODurations.TranslateSecondsToDuration(statistics.duration)
+	local utcOffset = DateTimeOffset.GetCurrentUtcOffset()
 
 	return self._cloudService
 		:GetToken(player)
@@ -364,11 +366,15 @@ function StyngrService:RequestNextTrack(player: Player)
 					statistics = {
 						{
 							trackId = session.track.trackId,
+							playlistId = session.playlistId,
 							start = DateTime.fromUnixTimestamp(statistics.started):ToIsoDate(),
 							duration = duration,
+							useType = 'streaming',
 							autoplay = true,
 							isMuted = false,
-							clientTimestampOffset = "",
+							endStreamReason = 'completed',
+							clientTimestampOffset = utcOffset,
+							playlistSessionId = session.sessionId,
 						},
 					},
 				}
@@ -407,6 +413,7 @@ function StyngrService:SkipTrack(player: Player)
 
 	local statistics = self:_endTrack(player.UserId)
 	local duration = ISODurations.TranslateSecondsToDuration(statistics.duration)
+	local utcOffset = DateTimeOffset.GetCurrentUtcOffset()
 
 	return self._cloudService
 		:GetToken(player)
@@ -421,11 +428,15 @@ function StyngrService:SkipTrack(player: Player)
 					statistics = {
 						{
 							trackId = session.track.trackId,
+							playlistId = session.playlistId,
 							start = DateTime.fromUnixTimestamp(statistics.started):ToIsoDate(),
 							duration = duration,
+							useType = 'streaming',
 							autoplay = true,
 							isMuted = false,
-							clientTimestampOffset = "",
+							endStreamReason = 'skip',
+							clientTimestampOffset = utcOffset,
+							playlistSessionId = session.sessionId,
 						},
 					},
 				}


### PR DESCRIPTION
- Added a utility function that captures the current user's timezone and calculates the offset from UTC
- Extended the `statistics` part of the payload for `/next` and `/skip` requests.
Although the previous implementation populated all the _required_ fields, some of the _optional_ ones caused an issue on the Styngr API side where `statistics` data would not be inserted into the database.
